### PR TITLE
Atualiza documentação para refletir API da Loja de Construção

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,146 @@
+# API REST
+
+Esta referência descreve os endpoints expostos pela API Loja de Construção. Todos os endpoints respondem em JSON e exigem `Content-Type: application/json` para requisições de escrita.
+
+- **Base URL local**: `http://localhost:8089`
+- **Prefixo**: `/api`
+
+## Convenções gerais
+
+- Identificadores são inteiros positivos (`Integer`).
+- Campos monetários (`valor`) são números decimais (`Double`).
+- Relações com filial utilizam o objeto `filial` no formato resumido (`idLancamento`, `nome`).
+- Regras de validação utilizam `ResponseStatusException`, retornando status `400 Bad Request` ou `404 Not Found` conforme o caso.
+
+## Filiais (`/api/FILIAL`)
+
+### Estruturas
+
+`FilialResumoDTO`
+```json
+{
+  "idLancamento": 1,
+  "nome": "Filial Centro"
+}
+```
+
+`FilialDetalheDTO`
+```json
+{
+  "idLancamento": 1,
+  "nome": "Filial Centro",
+  "ferramentas": [ ... ],
+  "materiais": [ ... ]
+}
+```
+
+### Endpoints
+
+| Método | Caminho | Descrição | Sucesso |
+|--------|---------|-----------|---------|
+| GET | `/api/FILIAL` | Lista todas as filiais cadastradas. | `200 OK` com array de `FilialResumoDTO`. |
+| GET | `/api/FILIAL/{id}` | Consulta detalhada com estoque de ferramentas e materiais. | `200 OK` com `FilialDetalheDTO`; `404` se não encontrado. |
+| POST | `/api/FILIAL` | Cria uma nova filial. | `201 Created` com `FilialDetalheDTO`; `400` se `nome` ausente ou em branco. |
+| PUT | `/api/FILIAL/{id}` | Atualiza o nome da filial. | `200 OK` com `FilialDetalheDTO`; `404` se não encontrado; `400` ao tentar alterar `idLancamento`. |
+| DELETE | `/api/FILIAL/{id}` | Remove a filial quando não há dependências. | `204 No Content`; `404` se não encontrado. |
+
+### Exemplo de criação
+
+```http
+POST /api/FILIAL HTTP/1.1
+Content-Type: application/json
+
+{
+  "nome": "Filial Aeroporto"
+}
+```
+
+Resposta
+```json
+{
+  "idLancamento": 5,
+  "nome": "Filial Aeroporto",
+  "ferramentas": [],
+  "materiais": []
+}
+```
+
+## Ferramentas (`/api/FERRAMENTA`)
+
+### Estrutura (`FerramentaDTO`)
+
+```json
+{
+  "codFerramenta": 12,
+  "codigoProduto": "FER-001",
+  "valor": 199.9,
+  "marca": "Bosch",
+  "nome": "Furadeira",
+  "qtdPacote": 5,
+  "filial": {
+    "idLancamento": 1,
+    "nome": "Filial Centro"
+  }
+}
+```
+
+### Endpoints
+
+| Método | Caminho | Descrição | Sucesso |
+|--------|---------|-----------|---------|
+| GET | `/api/FERRAMENTA` | Lista todas as ferramentas. | `200 OK` com array de `FerramentaDTO`. |
+| GET | `/api/FERRAMENTA/{id}` | Consulta uma ferramenta pelo identificador. | `200 OK` com `FerramentaDTO`; `404` se não encontrado. |
+| POST | `/api/FERRAMENTA` | Cria uma nova ferramenta vinculada a uma filial existente. | `201 Created` com `FerramentaDTO`; `400` se filial não informada; `404` se filial inexistente. |
+| PUT | `/api/FERRAMENTA/{id}` | Atualiza atributos da ferramenta. | `200 OK`; `404` se não encontrado. |
+| DELETE | `/api/FERRAMENTA/{id}` | Remove a ferramenta. | `204 No Content`; `404` se não encontrado. |
+
+### Regras específicas
+
+- O objeto `filial` é obrigatório nas operações de criação e atualização.
+- `codigoProduto`, `valor` e `nome` são obrigatórios; ausências resultam em `400 Bad Request`.
+
+## Materiais de construção (`/api/MATERIAL-CONSTRUCAO`)
+
+### Estrutura (`MaterialConstrucaoDTO`)
+
+```json
+{
+  "codMaterial": 33,
+  "codigoProduto": "MAT-003",
+  "valor": 59.9,
+  "cor": "Cinza",
+  "nome": "Cimento CP-II",
+  "materiaPrima": "Clínquer",
+  "filial": {
+    "idLancamento": 1,
+    "nome": "Filial Centro"
+  }
+}
+```
+
+### Endpoints
+
+| Método | Caminho | Descrição | Sucesso |
+|--------|---------|-----------|---------|
+| GET | `/api/MATERIAL-CONSTRUCAO` | Lista todos os materiais cadastrados. | `200 OK` com array de `MaterialConstrucaoDTO`. |
+| GET | `/api/MATERIAL-CONSTRUCAO/{id}` | Consulta um material específico. | `200 OK`; `404` se não encontrado. |
+| POST | `/api/MATERIAL-CONSTRUCAO` | Cria um novo material vinculado a uma filial existente. | `201 Created`; `400` se filial não informada; `404` se filial inexistente. |
+| PUT | `/api/MATERIAL-CONSTRUCAO/{id}` | Atualiza os atributos do material. | `200 OK`; `404` se não encontrado. |
+| DELETE | `/api/MATERIAL-CONSTRUCAO/{id}` | Remove o material. | `204 No Content`; `404` se não encontrado. |
+
+### Regras específicas
+
+- `codigoProduto`, `valor` e `nome` são obrigatórios; omissões retornam `400 Bad Request`.
+- O campo `filial` deve apontar para uma filial já cadastrada.
+
+## Erros comuns
+
+| Status | Quando ocorre |
+|--------|---------------|
+| `400 Bad Request` | Dados obrigatórios ausentes, tentativa de alterar ID de filial, filial não informada ao criar itens de estoque. |
+| `404 Not Found` | Recurso inexistente (filial, ferramenta ou material). |
+
+## Próximas extensões sugeridas
+
+- Documentar filtros de consulta quando disponíveis (por exemplo, por faixa de preço ou filial).
+- Expor documentação OpenAPI gerada automaticamente.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,63 +1,38 @@
-# Backlog (Genérico)
+# Backlog do Projeto
 
-> Este backlog é um **exemplo inicial** para organizar as tarefas do projeto. Adapte conforme necessário.
+O backlog prioriza as entregas necessárias para manter e evoluir a API da Loja de Construção. Os itens abaixo orientam o desenvolvimento incremental, desde a infraestrutura até funcionalidades específicas de estoque.
 
-## Labels sugeridas
+## Convenções
 
-- `tipo:bug`
-- `tipo:feature`
-- `tipo:task`
-- `prioridade:alta`
-- `prioridade:média`
-- `prioridade:baixa`
-- `status:em-planejamento`
-- `status:em-progresso`
-- `status:em-revisao`
-- `status:bloqueado`
-- `status:concluido`
+- **Labels**: `tipo:bug`, `tipo:feature`, `tipo:task`, `prioridade:alta`, `prioridade:média`, `prioridade:baixa`, `status:em-planejamento`, `status:em-progresso`, `status:em-revisao`, `status:bloqueado`, `status:concluido`.
+- **Kanban sugerido**: Backlog → Planejado → Em progresso → Em revisão → Concluído.
+- Cada item deve apontar para uma issue e conter critérios de aceitação verificáveis.
 
-## Colunas do Kanban
+## Roadmap inicial
 
-1. **Backlog** — ideias e tarefas não planejadas
-2. **Planejado** — pronto para ser iniciado
-3. **Em progresso** — em desenvolvimento
-4. **Em revisão** — aguardando revisão
-5. **Concluído** — finalizado e testado
+| ID   | Item | Critérios de Aceitação |
+|------|------|------------------------|
+| BK01 | Pipeline de build e publicação do MkDocs. | Deploy automático no GitHub Pages após merge na `main`. |
+| BK02 | Provisionamento local com Docker Compose. | `docker compose up --build` sobe API (`8089`), MySQL (`dbspringboot`) e Adminer (`8080`). |
+| BK03 | Configuração de CORS. | Requisições do front-end em `http://localhost:3000` devem ser aceitas sem erros. |
 
-## Itens iniciais
+## Histórias de usuário
 
-- **BK-1**: Configurar MkDocs e tema Material
-  _Critérios de aceite_: páginas iniciais prontas e navegação configurada.
+| ID   | História | Critérios de Aceitação |
+|------|----------|------------------------|
+| US01 | **Cadastro de filial** — Como gerente regional, quero cadastrar uma filial informando o nome para disponibilizá-la na rede. | `POST /api/FILIAL` com nome válido responde `201 Created` com dados completos; nome vazio gera `400 Bad Request`. |
+| US02 | **Atualização de filial** — Como gerente regional, quero atualizar o nome de uma filial existente. | `PUT /api/FILIAL/{id}` com nome válido responde `200 OK`; tentativa de alterar o código gera `400 Bad Request`. |
+| US03 | **Listagem de filiais** — Como executivo de expansão, quero listar todas as filiais. | `GET /api/FILIAL` retorna lista (possivelmente vazia) com `idLancamento` e `nome`. |
+| US04 | **Consulta detalhada da filial** — Como gerente de loja, quero consultar filiais com estoque completo. | `GET /api/FILIAL/{id}` retorna `ferramentas` e `materiais`; id inexistente responde `404 Not Found`. |
+| US05 | **Exclusão de filial** — Como administrador da rede, quero remover filiais encerradas. | `DELETE /api/FILIAL/{id}` devolve `204 No Content` quando remove; inexistente retorna `404`. |
+| US06 | **Cadastro de ferramenta** — Como gestor de estoque, quero registrar novas ferramentas vinculadas a uma filial. | `POST /api/FERRAMENTA` exige filial válida; respostas `201` no sucesso, `400` sem filial e `404` para filial inexistente. |
+| US07 | **Atualização de ferramenta** — Como gestor de estoque, quero manter dados corretos. | `PUT /api/FERRAMENTA/{id}` atualiza atributos e devolve `200`; id inexistente retorna `404`. |
+| US08 | **Listagem de ferramentas** — Como equipe de compras, quero visualizar todas as ferramentas cadastradas. | `GET /api/FERRAMENTA` traz itens com atributos e filial resumida. |
+| US09 | **Cadastro de material** — Como comprador corporativo, quero cadastrar novos materiais vinculados a uma filial. | `POST /api/MATERIAL-CONSTRUCAO` exige filial válida; respostas `201`, `400` ou `404` conforme regra. |
+| US10 | **Exclusão de material** — Como gestor de estoque, quero remover materiais descontinuados. | `DELETE /api/MATERIAL-CONSTRUCAO/{id}` devolve `204` ao remover; id inexistente retorna `404`. |
 
-- **BK-2**: Pipeline de deploy no GitHub Pages
-  _Critérios de aceite_: build automático e site publicado.
+## Próximas iniciativas
 
-- **BK-3**: Criar templates de issues
-  _Critérios de aceite_: templates disponíveis para bug, feature e task.
-
-## Backlog de Histórias de Usuário
-
-| ID   | História de Usuário | Critérios de Aceitação |
-|------|---------------------|-------------------------|
-| US01 | **Cadastro de filial** — Como gerente regional, quero cadastrar uma nova filial informando o nome para disponibilizá-la na rede. | - POST `/api/FILIAL` com nome válido → 201 Created com dados da filial.<br>- Nome ausente/branco → 400 Bad Request e não cria. |
-| US02 | **Atualização de filial** — Como gerente regional, quero atualizar o nome de uma filial existente para manter os dados corretos. | - PUT `/api/FILIAL/{id}` com nome válido → 200 OK com dados atualizados.<br>- Alterar código da filial → 400 Bad Request. |
-| US03 | **Listagem de filiais** — Como executivo de expansão, quero listar todas as filiais para planejar a cobertura da rede. | - GET `/api/FILIAL` → 200 OK com lista de filiais (código e nome).<br>- Sem filiais → 200 OK com lista vazia. |
-| US04 | **Consulta detalhada da filial** — Como gerente de loja, quero consultar os detalhes de uma filial, incluindo ferramentas e materiais, para acompanhar o estoque local. | - GET `/api/FILIAL/{id}` → 200 OK com nome da filial, ferramentas e materiais.<br>- Filial inexistente → 404 Not Found. |
-| US05 | **Exclusão de filial** — Como administrador da rede, quero remover uma filial que foi encerrada para manter o cadastro atualizado. | - DELETE `/api/FILIAL/{id}` → 204 No Content.<br>- ID inexistente → 404 Not Found. |
-| US06 | **Cadastro de ferramenta** — Como gestor de estoque, quero cadastrar uma nova ferramenta vinculada a uma filial para ampliar o portfólio disponível aos clientes. | - POST `/api/FERRAMENTA` completo → 201 Created com dados + filial resumida.<br>- Sem filial → 400 Bad Request.<br>- Filial inexistente → 404 Not Found. |
-| US07 | **Atualização de ferramenta** — Como gestor de estoque, quero atualizar dados de uma ferramenta para manter preços e informações corretos. | - PUT `/api/FERRAMENTA/{id}` válido → 200 OK com dados atualizados.<br>- ID inexistente → 404 Not Found. |
-| US08 | **Listagem de ferramentas** — Como equipe de compras, quero listar todas as ferramentas cadastradas para avaliar o portfólio da rede. | - GET `/api/FERRAMENTA` → 200 OK com lista de ferramentas.<br>- Cada item traz atributos + resumo da filial. |
-| US09 | **Cadastro de material de construção** — Como comprador corporativo, quero cadastrar um novo material vinculado a uma filial para ampliar as opções de venda. | - POST `/api/MATERIAL-CONSTRUCAO` completo → 201 Created com dados + filial resumida.<br>- Sem filial → 400 Bad Request.<br>- Filial inexistente → 404 Not Found. |
-| US10 | **Exclusão de material de construção** — Como gestor de estoque, quero remover um material que saiu de linha para manter o catálogo atualizado. | - DELETE `/api/MATERIAL-CONSTRUCAO/{id}` → 204 No Content.<br>- ID inexistente → 404 Not Found. |
-
-## História detalhada — Backend da loja de construção
-
-**Como** gerente de operações da rede de lojas de construção, **quero** administrar as filiais e seus estoques de materiais e ferramentas através da API REST do backend, **para** manter os dados consistentes em todas as unidades.
-
-### Critérios de aceitação
-
-- **Consulta de filiais**: chamadas `GET /api/FILIAL` e `GET /api/FILIAL/{id}` retornam respectivamente a lista de filiais e os detalhes de uma filial, incluindo o inventário agregado de ferramentas e materiais.
-- **Cadastro e atualização de filiais**: requisições `POST` e `PUT` validam a presença do nome e rejeitam tentativas de alterar o código primário existente, respondendo com **400 Bad Request** quando a regra é violada.
-- **Gestão de materiais de construção**: os endpoints de CRUD em `/api/MATERIAL-CONSTRUCAO` permitem criar, atualizar, listar e remover materiais vinculados a uma filial existente; vínculos ausentes ou inválidos produzem a resposta de erro apropriada.
-- **Gestão de ferramentas**: os endpoints de CRUD em `/api/FERRAMENTA` exigem filial válida para cada ferramenta; omissões ou referências inválidas geram erros de validação.
-- **Compatibilidade com front-end local**: quando o cliente é executado em `http://localhost:3000`, as requisições cross-origin são aceitas graças à configuração de CORS do backend.
+- Implementar paginação e filtros nos endpoints de listagem.
+- Adicionar autenticação/autorização para restringir o acesso à API.
+- Disponibilizar documentação OpenAPI gerada automaticamente a partir dos controllers.

--- a/docs/contribuindo.md
+++ b/docs/contribuindo.md
@@ -1,24 +1,38 @@
-# oCntribuindo
-Bem-vinde! Esta seção orienta como contribuir com este projeto.
+# Contribuindo
 
-## Fluxo de trabalho
+Bem-vinde! Esta seção orienta como colaborar com o backend e com esta documentação.
 
-1. Abra uma *issue* descrevendo o problema ou funcionalidade. Use os rótulos apropriados (`tipo:bug`, `tipo:feature`, etc.) e vincule-se a itens do backlog quando houver.
+## Fluxo de trabalho sugerido
+
+1. Abra uma issue descrevendo o problema ou a funcionalidade desejada. Use labels do backlog e vincule-se a itens existentes quando fizer sentido.
 2. Crie uma branch a partir de `main` com um nome descritivo, por exemplo:
-   - `feature/nova-funcionalidade`
-   - `bug/corrige-link-broken`
-   - `doc/ajusta-tutorial`
-3. Faça *commits* pequenos e com mensagens claras. Siga o padrão **imperativo** (ex.: `Adiciona página de contato`).
-4. Envie um *Pull Request* (PR) para `main`. No PR:
-   - Relacione a *issue* correspondente (ex.: "Closes #3").
-   - Descreva as mudanças realizadas.
-   - Marque revisores.
-5. Aguarde a revisão. Ajuste conforme os comentários.
-6. Depois de aprovado, o PR será mesclado. A automação de *deploy* publicará o site atualizado.
+   - `feature/cadastro-filial`
+   - `bugfix/corrige-validacao-ferramenta`
+   - `docs/atualiza-endpoints`
+3. Faça commits pequenos com mensagens no imperativo (ex.: `Ajusta validacao de filial`).
+4. Envie um Pull Request para `main` contendo:
+   - descrição das mudanças;
+   - referência para a issue relacionada (`Closes #ID`);
+   - evidências de testes executados (logs, prints, comandos).
+5. Aguarde a revisão, aplique ajustes solicitados e mantenha a branch atualizada com `main` quando necessário.
 
-## Boas práticas
+## Checklist antes de abrir PR
 
-- Mantenha a consistência do estilo e formatação.
-- Adicione testes ou exemplos quando possível.
-- Atualize a documentação em `docs/` e o `backlog.md` quando necessário.
-- Verifique se a pipeline de CI passa antes de solicitar revisão.
+- Executar `./mvnw test` (ou `mvnw.cmd test` no Windows) dentro de `springboot/demo`.
+- Rodar `docker compose up --build` localmente quando houver ajustes em infraestrutura.
+- Atualizar a documentação em `docs/` sempre que houver mudanças em endpoints ou contratos.
+- Garantir que o `mkdocs build` finalize sem erros.
+
+## Padrões de código e estilo
+
+- Utilize Lombok conforme já aplicado às entidades e DTOs, evitando duplicação de getters/setters.
+- Prefira lançar `ResponseStatusException` com mensagens claras em validações de negócio.
+- Mantenha os controllers enxutos, delegando regras para as classes de serviço.
+- Ao adicionar novas entidades, atualize `schema.sql` e revise a modelagem relacional.
+
+## Como sugerir melhorias na documentação
+
+1. Atualize ou crie arquivos em `docs/` utilizando Markdown e seguindo o tom adotado nas seções atuais.
+2. Rode `mkdocs serve` localmente para validar a navegação.
+3. Inclua capturas de tela ou exemplos de requisições quando relevante.
+4. Abra um PR específico para documentação com o label `tipo:doc`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,50 @@
-# Bem-vindo
+# Visão Geral
 
-Este site foi gerado com **MkDocs** e o tema **Material**. Ele inclui um backlog genérico e documentação em Português.
+A **API Loja de Construção** centraliza o cadastro de filiais, ferramentas e materiais de construção que abastecem a rede. Ela foi desenvolvida em Spring Boot e exposta como um conjunto de endpoints REST, consumidos por aplicações internas e painéis de gestão.
 
-Para navegar, utilize o menu lateral ou o topo do site para acessar as páginas.
+## Objetivos do projeto
+
+- Disponibilizar uma API única para o domínio de filiais e seus estoques.
+- Garantir consistência de dados entre ferramentas e materiais vinculados a cada filial.
+- Facilitar a integração com front-ends hospedados localmente (por exemplo, em `http://localhost:3000`) através de configuração de CORS.
+
+## Principais recursos
+
+- **Gestão de filiais**: CRUD completo, com validações para impedir alteração indevida do identificador da filial.
+- **Gestão de estoque**: registro de ferramentas e materiais com vínculo obrigatório a uma filial existente.
+- **Relacionamentos ricos**: respostas detalhadas incluem a filial resumida associada a cada item, e os detalhes de uma filial trazem o estoque completo.
+
+## Tecnologias adotadas
+
+- [Spring Boot](https://spring.io/projects/spring-boot) 3.x
+- JPA/Hibernate com banco MySQL
+- Lombok para redução de código repetitivo nas entidades e DTOs
+- Docker Compose para provisionar a API e o banco localmente
+
+## Como executar rapidamente
+
+### Usando Docker Compose
+
+```bash
+git clone https://github.com/MarcoTulioSoares/API-LOJA-DE-CONSTRU-O.git
+cd API-LOJA-DE-CONSTRU-O
+docker compose up --build
+```
+
+O serviço `api` será exposto em `http://localhost:8089` e utilizará o banco MySQL interno definido em `docker-compose.yml`.
+
+### Execução local com Maven Wrapper
+
+```bash
+git clone https://github.com/MarcoTulioSoares/API-LOJA-DE-CONSTRU-O.git
+cd API-LOJA-DE-CONSTRU-O/springboot/demo
+./mvnw spring-boot:run
+```
+
+Antes de iniciar, configure as variáveis de ambiente `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER` e `DB_PASS`, ou utilize os valores padrão (`localhost`, `3306`, `dbspringboot`, `root`, `root`).
+
+## Próximos passos
+
+- Consulte a página [API REST](api.md) para detalhes dos endpoints.
+- Acesse a seção [Arquitetura](sobre.md) para entender a organização do código e da base de dados.
+- Verifique o [backlog](backlog.md) para planejar evoluções do produto.

--- a/docs/sobre.md
+++ b/docs/sobre.md
@@ -1,5 +1,41 @@
-# Sobre
+# Arquitetura e Organização
 
-Esta documentação descreve o projeto e fornece informações importantes para desenvolvedores e usuários.
+Esta seção descreve a arquitetura do backend e como o código está estruturado para manter o domínio da loja de construção.
 
-Use as páginas deste site para obter contexto, guias e referências.
+## Camadas principais
+
+- **Controller**: expõe os endpoints REST sob o prefixo `/api`, separados em controllers específicos para filiais, ferramentas e materiais de construção. Cada controller delega a lógica para o respectivo serviço.
+- **Service**: concentra as regras de negócio, validação de dados e orquestração das entidades. Os serviços convertem entidades JPA para DTOs e fazem uso de `ResponseStatusException` para sinalizar problemas de validação.
+- **Repository**: interfaces JPA que comunicam com o banco MySQL. A configuração `spring.jpa.hibernate.ddl-auto=update` garante que o schema seja sincronizado conforme as entidades evoluem.
+- **DTOs e Entidades**: os DTOs expõem apenas os dados necessários para o consumo da API, enquanto as entidades refletem as tabelas físicas (`tb_filial`, `tb_ferramenta` e `tb_material_construcao`).
+
+## Banco de dados
+
+O script `schema.sql` cria três tabelas relacionadas por chaves estrangeiras:
+
+- `tb_filial`: cadastro das filiais com identificador `codigo_filial`.
+- `tb_ferramenta`: ferramentas com atributos como `marca`, `valor` e vínculo obrigatório com uma filial.
+- `tb_material_construcao`: materiais com dados de `cor`, `matéria-prima` e referência à filial de origem.
+
+As constraints `ON DELETE RESTRICT` evitam exclusão de filiais com itens associados. O carregamento dessas tabelas é garantido durante o boot da aplicação.
+
+## Configurações relevantes
+
+- **Porta**: por padrão, a API sobe em `8089`, podendo ser sobrescrita pela variável `PORT`.
+- **Banco de dados**: URLs, usuário e senha são obtidos das variáveis `MYSQLHOST`, `MYSQLPORT`, `MYSQLDATABASE`, `MYSQLUSER` e `MYSQLPASSWORD` (ou seus equivalentes `DB_*`).
+- **CORS**: o bean `CorsConfig` libera requisições de `http://localhost:3000`, permitindo o desenvolvimento de front-ends locais sem bloqueios de navegador.
+
+## Fluxo de dados
+
+1. Uma requisição chega a um endpoint `/api/...`.
+2. O controller correspondente valida o caminho e delega para o serviço.
+3. O serviço aplica regras de negócio (por exemplo, impedir alteração do ID da filial ou exigir vínculo com filial existente) e acessa os repositórios.
+4. As entidades retornadas são convertidas em DTOs para envio ao cliente.
+5. Em caso de erro, o serviço lança `ResponseStatusException` com status HTTP adequado (400, 404), propagado automaticamente pela camada web.
+
+## Entidades e relacionamentos
+
+- **FilialEntity** possui listas de ferramentas e materiais carregadas com `@OneToMany`, mantendo a consistência do estoque por filial.
+- **FerramentaEntity** e **MaterialConstrucaoEntity** utilizam `@ManyToOne` para referenciar a filial e armazenam atributos específicos de cada item.
+
+Essa organização permite adicionar novas categorias de estoque ou integrações externas preservando a separação de responsabilidades e a rastreabilidade de dados.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Documentação do Projeto
-site_description: Documentação com MkDocs e deploy automático no GitHub Pages
+site_name: API Loja de Construção
+site_description: Documentação oficial da API Loja de Construção
 site_url: https://MarcoTulioSoares.github.io/mkdocs-site
 repo_url: https://github.com/MarcoTulioSoares/mkdocs-site
 repo_name: MarcoTulioSoares/mkdocs-site
@@ -15,8 +15,9 @@ theme:
     - content.code.copy
 
 nav:
-  - Início: index.md
-  - Sobre: sobre.md
+  - Visão Geral: index.md
+  - Arquitetura: sobre.md
+  - API REST: api.md
   - Backlog: backlog.md
   - Contribuindo: contribuindo.md
 


### PR DESCRIPTION
## Summary
- reescreve a visão geral e a arquitetura destacando objetivos, camadas e configurações da API
- cria referência detalhada dos endpoints REST e ajusta o backlog e guia de contribuição para o projeto real
- atualiza a navegação e metadados do MkDocs para representar a documentação oficial da API Loja de Construção

## Testing
- not run (mkdocs build)


------
https://chatgpt.com/codex/tasks/task_e_68d9bbf1334083208a66bd6e40da08cc