### PR TITLE
Fix prototipo PDF links

### DIFF
--- a/docs/front.md
+++ b/docs/front.md
@@ -2,6 +2,6 @@
 
 Para uma melhor visualização do front-end.
 
-<embed src="pdf/prototipo.pdf" type="application/pdf" width="100%" height="600px" />
+<embed src="../pdf/prototipo.pdf" type="application/pdf" width="100%" height="600px" />
 
-Se preferir, [abra o prototipo em uma nova aba](pdf/ProjetoUML2_pagina2.pdf).
+Se preferir, [abra o prototipo em uma nova aba](../pdf/prototipo.pdf).


### PR DESCRIPTION
## Summary
- correct the PDF embed and link on the prototipo page to point to the proper location

## Testing
- not run (mkdocs not installed in environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc72f86d508320bd78c925fec8e8e1